### PR TITLE
Fixes

### DIFF
--- a/eelbrain/_trf/_boosting.py
+++ b/eelbrain/_trf/_boosting.py
@@ -307,10 +307,11 @@ def boosting(y, x, tstart, tstop, scale_data=True, delta=0.005, mindelta=None,
     x : NDVar | sequence of NDVar
         Signal to use to predict ``y``. Can be sequence of NDVars to include
         multiple predictors. Time dimension must correspond to ``y``.
-    tstart : float | list, tuple
-        Start of the TRF in seconds.
-    tstop : float | list, tuple
-        Stop of the TRF in seconds.
+    tstart : scalar | sequence of scalar
+        Start of the TRF in seconds. A list can be used to specify different
+        values for each item in ``x``.
+    tstop : scalar | sequence of scalar
+        Stop of the TRF in seconds. Format must match ``tstart``.
     scale_data : bool | 'inplace'
         Scale ``y`` and ``x`` before boosting: subtract the mean and divide by
         the standard deviation (when ``error='l2'``) or the mean absolute
@@ -333,10 +334,10 @@ def boosting(y, x, tstart, tstop, scale_data=True, delta=0.005, mindelta=None,
 
         For vector ``y``, the error is defined based on the distance in space
         for each data point.
-    basis : float
+    basis : scalar
         Use a basis of windows with this length for the kernel (by default,
         impulses are used).
-    basis_window : str | float | tuple
+    basis_window : str | scalar | tuple
         Basis window (see :func:`scipy.signal.get_window` for options; default
         is ``'hamming'``).
     partitions : int
@@ -598,14 +599,16 @@ def boost(y, x, x_pads, all_index, train_index, test_index, i_start, i_stop,
         Stimulus.
     x_pads : array (n_stims,)
         Padding for x.
+    all_index : array of (start, stop)
+        Time sample index of training and testing segments.
     train_index : array of (start, stop)
         Time sample index of training segments.
     test_index : array of (start, stop)
         Time sample index of test segments.
-    i_start : array
-        array of i_start for trfs.
-    i_stop : array
-        array of i_stop for TRF.
+    i_start : ndarray
+        Array of i_start for trfs.
+    i_stop : ndarray
+        Array of i_stop for TRF.
     delta : scalar
         Step of the adjustment.
     mindelta : scalar

--- a/eelbrain/_trf/_boosting_opt.pyx
+++ b/eelbrain/_trf/_boosting_opt.pyx
@@ -139,18 +139,20 @@ def generate_options(
         FLOAT64 [:] x_pads,  # (n_stims,)
         INT8 [:] x_active,  # for each predictor whether it is still used
         INT64 [:,:] indexes,  # training segment indexes
-        INT64[:] i_start,  # kernel start index (y/x offset)
+        int i_start,  # kernel start index (time axis offset)
+        INT64 [:] i_start_by_x,  # (n_stims,) kernel start index
+        INT64 [:] i_stop_by_x, # (n_stims,) kernel stop index
         size_t error,  # ID of the error function (l1/l2)
         double delta,
         # buffers
-        FLOAT64 [:,:] new_error,  # (n_stims, trf_length)
-        INT64[:] i_stop, # (n_stims,) has stop of each trf
-        INT8 [:,:] new_sign,
+        FLOAT64 [:,:] new_error,  # (n_stims, n_times_trf)
+        INT8 [:,:] new_sign,  # (n_stims, n_times_trf)
     ):
     cdef:
         double e_add, e_sub, x_pad
         size_t n_stims = new_error.shape[0]
-        size_t i_stim, i_time
+        size_t i_stim
+        int i_time
         FLOAT64 [:] x_stim
 
     if error != 1 and error != 2:
@@ -162,13 +164,14 @@ def generate_options(
                 continue
             x_stim = x[i_stim]
             x_pad = x_pads[i_stim]
-            for i_time in range(i_stop[i_stim]):
+            for i_time in range(i_start_by_x[i_stim], i_stop_by_x[i_stim]):
                 # +/- delta
                 if error == 1:
-                    l1_for_delta(y_error, x_stim, x_pad, indexes, delta, i_time + i_start[i_stim], &e_add, &e_sub)
+                    l1_for_delta(y_error, x_stim, x_pad, indexes, delta, i_time, &e_add, &e_sub)
                 else:
-                    l2_for_delta(y_error, x_stim, x_pad, indexes, delta, i_time + i_start[i_stim], &e_add, &e_sub)
+                    l2_for_delta(y_error, x_stim, x_pad, indexes, delta, i_time, &e_add, &e_sub)
 
+                i_time -= i_start
                 if e_add > e_sub:
                     new_error[i_stim, i_time] = e_sub
                     new_sign[i_stim, i_time] = -1

--- a/eelbrain/_trf/shared.py
+++ b/eelbrain/_trf/shared.py
@@ -315,7 +315,7 @@ class RevCorrData:
             tstart1 = res.tstart
         i_start = int(round(tstart1 / self.time.tstep))
         for y, h in zip(self.y, h_flat):
-            y -= convolve(h, x, x_pads, i_start, None, self.segments)
+            y -= convolve(h, x, x_pads, i_start, self.segments)
         # remove prefit predictors
         keep = np.setdiff1d(np.arange(n_x), h_index)
         self.x = self.x[keep]

--- a/eelbrain/_trf/tests/test_boosting.py
+++ b/eelbrain/_trf/tests/test_boosting.py
@@ -268,20 +268,15 @@ def test_trf_len(n_workers):
     res = boosting(y4, x4, 0, 0.5)
     assert correlation_coefficient(res.h, k4) > 0.99
 
-    # test multiple tstart, tend with 1d, 2d predictors
+    # test multiple tstart, tstop with 1d, 2d predictors
     y5 = y4 + y2
-    res = boosting(y5, [x, x2, x4], [0, -0.1, 0, 0], [0.5, 0.3, 0.5, 0.5])
+    res = boosting(y5, [x, x2, x4], [0, -0.1, 0], [0.5, 0.3, 0.5])
     assert correlation_coefficient(res.h[0].sub(time=(0, 0.5)), k) > 0.99
     assert correlation_coefficient(res.h[1].sub(time=(-0.1, 0.3)), k2) > 0.99
     assert correlation_coefficient(res.h[2].sub(time=(0, 0.5)), k4) > 0.99
 
-    # tests duplicating tstart, tend based on data._x_meta
-    y5.name = 'y5'
-    x.name = 'x'
-    x2.name = 'x2'
-    x4.name = 'x4'
-    res2 = boosting(y5, [x, x2, x4], [0, -0.1, 0], [0.5, 0.3, 0.5])
-    assert_array_equal(res.h[0], res2.h[0])
-    assert_array_equal(res.h[1], res2.h[1]) 
-    assert_array_equal(res.h[2], res2.h[2])
-
+    # tests tstart/tstop for each time series (not implemented)
+    # res2 = boosting(y5, [x, x2, x4], [0, -0.1, 0, 0], [0.5, 0.3, 0.5, 0.5])
+    # assert_array_equal(res.h[0], res2.h[0])
+    # assert_array_equal(res.h[1], res2.h[1])
+    # assert_array_equal(res.h[2], res2.h[2])

--- a/eelbrain/_trf/tests/test_boosting.py
+++ b/eelbrain/_trf/tests/test_boosting.py
@@ -229,13 +229,14 @@ def test_boosting_func():
     # svdboostV4pred multiplies error by number of predictors
     assert_allclose(test_sse_history, mat['Str_testE'][0] / 3)
 
+
 @pytest.mark.parametrize('n_workers', [0, True])
 def test_trf_len(n_workers):
     configure(n_workers=n_workers)
     # test vanilla boosting
     rng = np.random.RandomState(0)
-    x = NDVar(rng.normal(0, 1, 1000), UTS(0, 0.1, 1000),name='x')
-    k = NDVar(rng.randint(0, 10, 5) / 10, UTS(0, 0.1, 5),name='k')
+    x = NDVar(rng.normal(0, 1, 1000), UTS(0, 0.1, 1000), name='x')
+    k = NDVar(rng.randint(0, 10, 5) / 10, UTS(0, 0.1, 5), name='k')
     y = convolve(k, x)
     y.name = 'y'
     res = boosting(y, x, 0, 0.5)

--- a/eelbrain/_trf/tests/test_boosting.py
+++ b/eelbrain/_trf/tests/test_boosting.py
@@ -240,14 +240,16 @@ def test_trf_len(n_workers):
     y = convolve(k, x, name='y')
     res = boosting(y, x, 0, 0.5, partitions=3)
     assert correlation_coefficient(res.h, k) > 0.99
+    assert repr(res) == '<boosting y ~ x, 0 - 0.5, partitions=3>'
 
     # test multiple tstart, tend
-    x2 = NDVar(rng.normal(0, 1, 1000), UTS(0, 0.1, 1000))
-    k2 = NDVar(rng.randint(0, 10, 4) / 10, UTS(-0.1, 0.1, 4))
+    x2 = NDVar(rng.normal(0, 1, 1000), UTS(0, 0.1, 1000), name='x2')
+    k2 = NDVar(rng.randint(0, 10, 4) / 10, UTS(-0.1, 0.1, 4), name='k2')
     y2 = y + convolve(k2, x2)
     res = boosting(y2, [x, x2], [0, -0.1], [0.5, 0.3], partitions=3)
     assert correlation_coefficient(res.h[0].sub(time=(0, 0.5)), k) > 0.99
     assert correlation_coefficient(res.h[1].sub(time=(-0.1, 0.3)), k2) > 0.99
+    assert repr(res) == '<boosting y ~ x (0 - 0.5) + x2 (-0.1 - 0.3), partitions=3>'
 
     # test scalar res.tstart res.tstop
     res = boosting(y2, [x, x2], 0, 0.5, partitions=3)


### PR DESCRIPTION
I refactored it to keep the `h` time axis aligned across `x`. I think that makes internal functions easier to understand, and it turns out `convolve`/padding is fine because a TRF that starts at `i=5` is equivalent to a TRF that starts at `i=0` with `trf[:5] = 0`. I also made some stylistic changes. Let me know if you have questions on anything!